### PR TITLE
SLING-9313 - Content Package Installer: do not return an InstallTask if the TaskResource is of an unsupported type

### DIFF
--- a/src/main/java/org/apache/sling/installer/factory/packages/impl/PackageTransformer.java
+++ b/src/main/java/org/apache/sling/installer/factory/packages/impl/PackageTransformer.java
@@ -236,9 +236,8 @@ public class PackageTransformer implements ResourceTransformer, InstallTaskFacto
             }
             break;
         default:
-            String message = MessageFormat.format("Unupported type of {0}: {1}.", resource, resource.getType());
-            logger.error(message);
-            task = new ChangeStateTask(toActivate, ResourceState.IGNORED, message);
+            String message = MessageFormat.format("Unsupported type of {0}: {1}.", resource, resource.getType());
+            logger.debug(message);
         }
         return task;
     }


### PR DESCRIPTION
* return null if the `TaskResource` is of an unsupported type
* corrected typo and log cases where a `TaskResource` is unsupported on the debug level